### PR TITLE
Ignore virtual env

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -87,6 +87,8 @@ def main(argv: list[str] | None = None) -> int:
     all_files: set[Path] = set()
     for path_str in args.paths:
         path = Path(path_str).resolve()
+        if path == sys.prefix:  # ignore virtual env
+            continue
         if path.is_file():
             all_files.add(path)
         elif path.is_dir():

--- a/src/cli.py
+++ b/src/cli.py
@@ -87,7 +87,8 @@ def main(argv: list[str] | None = None) -> int:
     all_files: set[Path] = set()
     for path_str in args.paths:
         path = Path(path_str).resolve()
-        if path == sys.prefix:  # ignore virtual env
+        venv_path = Path(sys.prefix).resolve()
+        if path.samefile(venv_path):
             continue
         if path.is_file():
             all_files.add(path)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Skip the sys.prefix directory to prevent including the virtual environment in file collection